### PR TITLE
Basic python 3 compatibility

### DIFF
--- a/MKVToolNix/MKVToolNixURLProvider.py
+++ b/MKVToolNix/MKVToolNixURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import
 import re, urllib2, urlparse
 
 from HTMLParser import HTMLParser
@@ -73,7 +74,7 @@ class MKVToolNixURLProvider(Processor):
 					download_urls[version] = url
 
 			return download_urls
-		except urllib2.HTTPError, ValueError:
+		except urllib2.HTTPError as ValueError:
 			raise ProcessorError("Could not parse downloads metadata.")
 
 	def get_highest_version(self, versions):

--- a/MKVToolNix/MKVToolNixURLProvider.py
+++ b/MKVToolNix/MKVToolNixURLProvider.py
@@ -3,12 +3,20 @@
 from __future__ import absolute_import
 
 import re
-import urllib2
-import urlparse
 from distutils.version import StrictVersion
-from HTMLParser import HTMLParser
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlparse  # For Python 3
+    from urllib.request import urlopen
+    from urllib.error import HTTPError
+    from html.parser import HTMLParser
+except ImportError:
+    import urlparse  # For Python 2
+    from urllib2 import urlopen
+    from urllib2 import HTTPError
+    from HTMLParser import HTMLParser
 
 __all__ = ["MKVToolNixURLProvider"]
 
@@ -25,7 +33,7 @@ class URLFinder(HTMLParser):
 
     @staticmethod
     def get_all_urls_for_url(url):
-        content = urllib2.urlopen(url).read()
+        content = urlopen(url).read()
         parser = URLFinder()
         parser.feed(content)
         return parser.urls
@@ -72,7 +80,7 @@ class MKVToolNixURLProvider(Processor):
                     download_urls[version] = url
 
             return download_urls
-        except urllib2.HTTPError as ValueError:
+        except HTTPError as ValueError:
             raise ProcessorError("Could not parse downloads metadata.")
 
     def get_highest_version(self, versions):

--- a/MKVToolNix/MKVToolNixURLProvider.py
+++ b/MKVToolNix/MKVToolNixURLProvider.py
@@ -1,10 +1,13 @@
 #!/usr/bin/python
 
 from __future__ import absolute_import
-import re, urllib2, urlparse
 
-from HTMLParser import HTMLParser
+import re
+import urllib2
+import urlparse
 from distutils.version import StrictVersion
+from HTMLParser import HTMLParser
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = [ "MKVToolNixURLProvider" ]

--- a/MKVToolNix/MKVToolNixURLProvider.py
+++ b/MKVToolNix/MKVToolNixURLProvider.py
@@ -10,109 +10,108 @@ from HTMLParser import HTMLParser
 
 from autopkglib import Processor, ProcessorError
 
-__all__ = [ "MKVToolNixURLProvider" ]
+__all__ = ["MKVToolNixURLProvider"]
+
 
 class URLFinder(HTMLParser):
-	urls = []
+    urls = []
 
-	def handle_starttag(self, tag, attrs):
-		if tag == "a":
-			for key, value in attrs:
-				if key == "href":
-					self.urls.append(value)
-					break
+    def handle_starttag(self, tag, attrs):
+        if tag == "a":
+            for key, value in attrs:
+                if key == "href":
+                    self.urls.append(value)
+                    break
 
-	@staticmethod
-	def get_all_urls_for_url(url):
-		content = urllib2.urlopen(url).read()
-		parser = URLFinder()
-		parser.feed(content)
-		return parser.urls
+    @staticmethod
+    def get_all_urls_for_url(url):
+        content = urllib2.urlopen(url).read()
+        parser = URLFinder()
+        parser.feed(content)
+        return parser.urls
 
 
 class MKVToolNixURLProvider(Processor):
-	"""Provides a version number and dmg download url for MKVToolNix."""
-	description = __doc__
+    """Provides a version number and dmg download url for MKVToolNix."""
 
-	source_url = "https://mkvtoolnix.download/macos/"
-	url_pattern = "/macos/MKVToolNix-([0-9.]+).dmg"
+    description = __doc__
 
-	input_variables = {
-		"source_url": {
-			"required": False,
-			"description":
-				"URL that will be parsed for the final download URL."
-				"Default value is 'https://mkvtoolnix.download/macos/'"
-		},
-		"url_pattern": {
-			"required": False,
-			"description":
-				"Regex pattern that will applied to all URLs found on the"
-				"download page. Extracted version number will be evaluated"
-				"by distutils StrictVersion."
-				"Default value is '/macos/MKVToolNix-([0-9.]+).dmg'"
-		},
-	}
+    source_url = "https://mkvtoolnix.download/macos/"
+    url_pattern = "/macos/MKVToolNix-([0-9.]+).dmg"
 
-	output_variables = {
-		"version": {
-			"description": "Selected Version.",
-		},
-		"url": {
-			"description": "Download URL.",
-		},
-	}
+    input_variables = {
+        "source_url": {
+            "required": False,
+            "description": "URL that will be parsed for the final download URL."
+            "Default value is 'https://mkvtoolnix.download/macos/'",
+        },
+        "url_pattern": {
+            "required": False,
+            "description": "Regex pattern that will applied to all URLs found on the"
+            "download page. Extracted version number will be evaluated"
+            "by distutils StrictVersion."
+            "Default value is '/macos/MKVToolNix-([0-9.]+).dmg'",
+        },
+    }
 
+    output_variables = {
+        "version": {"description": "Selected Version."},
+        "url": {"description": "Download URL."},
+    }
 
-	def get_download_urls_per_version(self):
-		try:
-			urls = URLFinder.get_all_urls_for_url(self.source_url)
-			url_pattern = re.compile(self.url_pattern)
+    def get_download_urls_per_version(self):
+        try:
+            urls = URLFinder.get_all_urls_for_url(self.source_url)
+            url_pattern = re.compile(self.url_pattern)
 
-			download_urls = {}
-			for url in urls:
-				m = url_pattern.search(url)
-				if not (m is None):
-					version = m.group(1)
-					download_urls[version] = url
+            download_urls = {}
+            for url in urls:
+                m = url_pattern.search(url)
+                if not (m is None):
+                    version = m.group(1)
+                    download_urls[version] = url
 
-			return download_urls
-		except urllib2.HTTPError as ValueError:
-			raise ProcessorError("Could not parse downloads metadata.")
+            return download_urls
+        except urllib2.HTTPError as ValueError:
+            raise ProcessorError("Could not parse downloads metadata.")
 
-	def get_highest_version(self, versions):
-		versions = map(lambda x: (x, StrictVersion(x)), versions)
+    def get_highest_version(self, versions):
+        versions = map(lambda x: (x, StrictVersion(x)), versions)
 
-		has_changed = True
-		selected = versions[0]
-		while has_changed:
-			has_changed = False
-			for version in versions:
-				if selected[1] < version[1]:
-					has_changed = True
-					selected = version
+        has_changed = True
+        selected = versions[0]
+        while has_changed:
+            has_changed = False
+            for version in versions:
+                if selected[1] < version[1]:
+                    has_changed = True
+                    selected = version
 
-		return selected[0]
+        return selected[0]
 
-	def main(self):
-		if 'source_url' in self.env:
-			self.source_url = self.env['source_url']
-		if 'url_pattern' in self.env:
-			self.url_pattern = self.env['url_pattern']
+    def main(self):
+        if "source_url" in self.env:
+            self.source_url = self.env["source_url"]
+        if "url_pattern" in self.env:
+            self.url_pattern = self.env["url_pattern"]
 
-		try:
-			download_urls = self.get_download_urls_per_version()
-			latest_version = self.get_highest_version(download_urls.keys())
-			latest_version_url = download_urls[latest_version]
+        try:
+            download_urls = self.get_download_urls_per_version()
+            latest_version = self.get_highest_version(download_urls.keys())
+            latest_version_url = download_urls[latest_version]
 
-			self.output("Found download URL for {}: {}".format(latest_version, latest_version_url))
+            self.output(
+                "Found download URL for {}: {}".format(
+                    latest_version, latest_version_url
+                )
+            )
 
-			self.env["version"] = latest_version
-			self.env["url"] = urlparse.urljoin(self.source_url, latest_version_url)
-		except BaseException as e:
-			raise ProcessorError("Could not get a download URL: {}".format(e))
+            self.env["version"] = latest_version
+            self.env["url"] = urlparse.urljoin(self.source_url, latest_version_url)
+        except BaseException as e:
+            raise ProcessorError("Could not get a download URL: {}".format(e))
 
 
 if __name__ == "__main__":
-	PROCESSOR = MKVToolNixURLProvider()
-	PROCESSOR.execute_shell()
+    PROCESSOR = MKVToolNixURLProvider()
+    PROCESSOR.execute_shell()

--- a/SharedProcessor/DebugPrint.py
+++ b/SharedProcessor/DebugPrint.py
@@ -8,7 +8,10 @@ from autopkglib import Processor, ProcessorError
 __all__ = [ "DebugPrint" ]
 
 class DebugPrint(Processor):
-	"""Print a variable in console. Useful to debug."""
+	"""Print a variable in console.
+
+	Useful to debug.
+	"""
 	description = __doc__
 
 	input_variables = {

--- a/SharedProcessor/DebugPrint.py
+++ b/SharedProcessor/DebugPrint.py
@@ -5,33 +5,34 @@ from __future__ import absolute_import, print_function
 
 from autopkglib import Processor, ProcessorError
 
-__all__ = [ "DebugPrint" ]
+__all__ = ["DebugPrint"]
+
 
 class DebugPrint(Processor):
-	"""Print a variable in console.
+    """Print a variable in console.
 
-	Useful to debug.
-	"""
-	description = __doc__
+    Useful to debug.
+    """
 
-	input_variables = {
-		"variable_name": {
-			"required": True,
-			"description": "The name of the variable to print."
-		}
-	}
+    description = __doc__
 
-	output_variables = {
-	}
+    input_variables = {
+        "variable_name": {
+            "required": True,
+            "description": "The name of the variable to print.",
+        }
+    }
 
-	def main(self):
-		variable_name = self.env['variable_name']
-		if variable_name == "*":
-			print(self.env)
-		else:
-			print(self.env[variable_name])
+    output_variables = {}
+
+    def main(self):
+        variable_name = self.env["variable_name"]
+        if variable_name == "*":
+            print(self.env)
+        else:
+            print(self.env[variable_name])
 
 
 if __name__ == "__main__":
-	PROCESSOR = DebugPrint()
-	PROCESSOR.execute_shell()
+    PROCESSOR = DebugPrint()
+    PROCESSOR.execute_shell()

--- a/SharedProcessor/DebugPrint.py
+++ b/SharedProcessor/DebugPrint.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+from __future__ import print_function
 from autopkglib import Processor, ProcessorError
 
 __all__ = [ "DebugPrint" ]
@@ -22,9 +24,9 @@ class DebugPrint(Processor):
 	def main(self):
 		variable_name = self.env['variable_name']
 		if variable_name == "*":
-			print self.env
+			print(self.env)
 		else:
-			print self.env[variable_name]
+			print(self.env[variable_name])
 
 
 if __name__ == "__main__":

--- a/SharedProcessor/DebugPrint.py
+++ b/SharedProcessor/DebugPrint.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = [ "DebugPrint" ]

--- a/SharedProcessor/RegexReplace.py
+++ b/SharedProcessor/RegexReplace.py
@@ -10,8 +10,9 @@ from autopkglib import Processor, ProcessorError
 __all__ = [ "RegexReplace" ]
 
 class RegexReplace(Processor):
-	"""
-	Replaces sequence of the input that matches the pattern with the given replacement string.
+	"""Replaces sequence of the input that matches the pattern with the given
+	replacement string.
+
 	If the pattern isn't found, string is returned unchanged.
 	https://docs.python.org/2/library/re.html#re.sub
 	"""

--- a/SharedProcessor/RegexReplace.py
+++ b/SharedProcessor/RegexReplace.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 import re
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessor/RegexReplace.py
+++ b/SharedProcessor/RegexReplace.py
@@ -7,77 +7,68 @@ import re
 
 from autopkglib import Processor, ProcessorError
 
-__all__ = [ "RegexReplace" ]
+__all__ = ["RegexReplace"]
+
 
 class RegexReplace(Processor):
-	"""Replaces sequence of the input that matches the pattern with the given
-	replacement string.
+    """Replaces sequence of the input that matches the pattern with the given
+    replacement string.
 
-	If the pattern isn't found, string is returned unchanged.
-	https://docs.python.org/2/library/re.html#re.sub
-	"""
-	description = __doc__
+    If the pattern isn't found, string is returned unchanged.
+    https://docs.python.org/2/library/re.html#re.sub
+    """
 
-	input_variables = {
-		"result_output_var_name": {
-			"required": True,
-			"description":
-				"The name of the output variable that is returned by the replacement."
-		},
-		"re_string": {
-			"required": True,
-			"description":
-				"The sequence to "
-		},
-		"re_pattern": {
-			"required": True,
-			"description":
-				"Regular expression (Python) to match against page.",
-		},
-		"re_replacement": {
-			"required": True,
-			"description": "Replacement for the rege",
-		},
-		"re_flags": {
-			"required": False,
-			"description":
-				"Optional array of strings of Python regular expression "
-				"flags. E.g. IGNORECASE."
-		}
-	}
+    description = __doc__
 
-	output_variables = {
-		"result_output_var_name": {
-			"description":
-				"First matched sub-pattern from 're_string'. Note the actual name "
-				"of variable depends on the input variable 'result_output_var_name'"
-		}
-	}
+    input_variables = {
+        "result_output_var_name": {
+            "required": True,
+            "description": "The name of the output variable that is returned by the replacement.",
+        },
+        "re_string": {"required": True, "description": "The sequence to "},
+        "re_pattern": {
+            "required": True,
+            "description": "Regular expression (Python) to match against page.",
+        },
+        "re_replacement": {"required": True, "description": "Replacement for the rege"},
+        "re_flags": {
+            "required": False,
+            "description": "Optional array of strings of Python regular expression "
+            "flags. E.g. IGNORECASE.",
+        },
+    }
 
-	def replace(self, pattern, replacement, string, flags):
-		# https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/URLTextSearcher.py#L91
-		flag_accumulator = 0
-		if flags:
-			for flag in flags:
-				if flag in re.__dict__:
-					flag_accumulator += re.__dict__[flag]
+    output_variables = {
+        "result_output_var_name": {
+            "description": "First matched sub-pattern from 're_string'. Note the actual name "
+            "of variable depends on the input variable 'result_output_var_name'"
+        }
+    }
 
-		return re.sub(pattern, replacement, string, flags=flag_accumulator)
+    def replace(self, pattern, replacement, string, flags):
+        # https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/URLTextSearcher.py#L91
+        flag_accumulator = 0
+        if flags:
+            for flag in flags:
+                if flag in re.__dict__:
+                    flag_accumulator += re.__dict__[flag]
 
-	def main(self):
-		output_var_name = self.env['result_output_var_name']
+        return re.sub(pattern, replacement, string, flags=flag_accumulator)
 
-		re_string = self.env['re_string']
-		re_replacement = self.env['re_replacement']
+    def main(self):
+        output_var_name = self.env["result_output_var_name"]
 
-		re_pattern = self.env['re_pattern']
-		re_flags = self.env['re_flags']
+        re_string = self.env["re_string"]
+        re_replacement = self.env["re_replacement"]
 
-		result = self.replace(re_pattern, re_replacement, re_string, re_flags)
+        re_pattern = self.env["re_pattern"]
+        re_flags = self.env["re_flags"]
 
-		self.env[output_var_name] = result
+        result = self.replace(re_pattern, re_replacement, re_string, re_flags)
+
+        self.env[output_var_name] = result
 
 
 if __name__ == "__main__":
-	PROCESSOR = RegexReplace()
-	PROCESSOR.execute_shell()
+    PROCESSOR = RegexReplace()
+    PROCESSOR.execute_shell()

--- a/SharedProcessor/RegexReplace.py
+++ b/SharedProcessor/RegexReplace.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
+
 import re
 
 from autopkglib import Processor, ProcessorError


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including the two items below), but this should catch the low-hanging fruit right now.

```
MKVToolNix/MKVToolNixURLProvider.py
************* Module MKVToolNixURLProvider
W: 87,19: map built-in referenced when not iterating (map-builtin-not-iterating)
W:108,54: dict.keys referenced when not iterating (dict-keys-not-iterating)
```