### PR TITLE
Setup devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+FROM mcr.microsoft.com/devcontainers/base:trixie
+
+COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /uvx /bin/
+
+RUN set -ex \
+	&& apt update \
+	&& apt install -y \
+		build-essential \
+		libffi-dev \
+		libxml2-dev \
+		libxslt1-dev
+
+RUN set -ex \
+	&& cd /opt \
+	&& git clone --depth=1 --branch=v2.9.0 https://github.com/autopkg/autopkg.git
+
+RUN set -ex \
+	&& cd /opt/autopkg \
+	&& export UV_PYTHON_INSTALL_DIR=/opt/autopkg/Python \
+	&& uv python pin 3.11 \
+	&& uv venv \
+	&& uv pip install -r requirements.txt
+
+COPY autopkg /usr/local/bin/

--- a/.devcontainer/autopkg
+++ b/.devcontainer/autopkg
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /opt/autopkg/.venv/bin/python /opt/autopkg/Code/autopkg "$@"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "Debian",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"EditorConfig.EditorConfig",
+				"ms-python.python",
+				"ms-python.debugpy",
+				"ms-python.pylint",
+				"ms-python.isort",
+				"charliermarsh.ruff"
+			]
+		}
+	}
+}


### PR DESCRIPTION
Basic Debian setup with UV and Autopkg installed in `/opt/autopkg` and a command in `/usr/local/bin/autopkg`.