### PR TITLE
Update CodeSignatureVerifier for MKVToolNix download recipe

### DIFF
--- a/MKVToolNix/MKVToolNix.download.recipe
+++ b/MKVToolNix/MKVToolNix.download.recipe
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/MKVToolNix-*.app</string>
+				<string>%pathname%/MKVToolNix.app</string>
 				<key>requirement</key>
-				<string>identifier "download.mkvtoolnix.MKVToolNix" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YZ9DVS8D8C</string>
+				<string>identifier "download.mkvtoolnix.MKVToolNix" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = H4MM26UAYB</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Thank you for fixing the script in #12! I just got back from MacDevOps and hadn't had a chance to take a look. 😅 

Amazingly, the developer changed the app bundle to _finally_ not include the version in the name, and also changed the signing certificate. I updated both of those, and both the .download and .munki recipes work great with the updated provider script.

Thanks again for maintaining this! I don't need this app often, but when I do, it's extremely convenient!